### PR TITLE
Improve host detection for mobile OCR

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,7 +16,10 @@ import { Platform } from 'react-native';
 function guessHost(): string {
   if (process.env.EXPO_PUBLIC_DEV_HOST) return process.env.EXPO_PUBLIC_DEV_HOST;
 
-  const uri = Constants?.expoConfig?.hostUri ?? '';
+  const uri =
+    Constants?.expoConfig?.hostUri ||
+    Constants?.expoGoConfig?.debuggerHost ||
+    '';
   if (uri) return uri.split(':').shift()!; // "192.168.0.23" when hostUri="192.168.0.23:8081"
 
   if (Platform.OS === 'android') return '10.0.2.2';
@@ -31,7 +34,6 @@ function guessHost(): string {
 export const HOST_GUESS = guessHost();
 
 if (__DEV__) {
-  // eslint-disable-next-line no-console
   console.info(`[ChemFetch] guessHost() resolved to: ${HOST_GUESS}`);
 }
 


### PR DESCRIPTION
## Summary
- ensure mobile app can locate backend by also checking Expo Go debuggerHost when guessing host

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: unable to resolve modules)
- `npx eslint lib/constants.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f4df39580832f91875bc997c15629